### PR TITLE
Fix error which is not able to find PersistentEntity when getting LeaguePositionDTOs

### DIFF
--- a/src/main/java/org/cnu/realcoding/riotpractice/api/LeaguePositionDTOApiClient.java
+++ b/src/main/java/org/cnu/realcoding/riotpractice/api/LeaguePositionDTOApiClient.java
@@ -1,11 +1,12 @@
 package org.cnu.realcoding.riotpractice.api;
 
+import org.cnu.realcoding.riotpractice.domain.LeaguePositionDTO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
@@ -15,10 +16,12 @@ public class LeaguePositionDTOApiClient {
     private final String apiKey = "RGAPI-504c9e37-6e3b-4913-ae19-c194c8941431";
     private final String leaguePositionUri = "https://kr.api.riotgames.com/lol/league/v4/positions/by-summoner/{encryptedSummonerId}?api_key={apiKey}";
 
-    public LinkedHashMap getLeaguePositionDTO(String encryptedSummonerId) {
-        List<LinkedHashMap> leaguePositionDTOList = restTemplate.exchange(leaguePositionUri, HttpMethod.GET, null, List.class, encryptedSummonerId, apiKey)
+    private final ParameterizedTypeReference<List<LeaguePositionDTO>> responseType = new ParameterizedTypeReference<List<LeaguePositionDTO>>() {};
+
+    public List<LeaguePositionDTO> getLeaguePositionDTO(String encryptedSummonerId) {
+        List<LeaguePositionDTO> leaguePositionDTOList = restTemplate.exchange(leaguePositionUri, HttpMethod.GET, null, responseType, encryptedSummonerId, apiKey)
                 .getBody();
 
-        return leaguePositionDTOList.get(0); //leaguePositionDTO.get(0);
+        return leaguePositionDTOList;
     }
 }

--- a/src/main/java/org/cnu/realcoding/riotpractice/controller/SummonerController.java
+++ b/src/main/java/org/cnu/realcoding/riotpractice/controller/SummonerController.java
@@ -1,6 +1,7 @@
 package org.cnu.realcoding.riotpractice.controller;
 
 
+import org.cnu.realcoding.riotpractice.domain.LeaguePositionDTO;
 import org.cnu.realcoding.riotpractice.service.SummonerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.LinkedHashMap;
+import java.util.List;
 
 // http://localhost:8080/riot-practice
 
@@ -19,7 +20,7 @@ public class SummonerController {
     private SummonerService summonerService;
 
     @GetMapping("/league-position/{summonerName}")
-    public LinkedHashMap getLeaguePositionDTO(@PathVariable String summonerName) {
+    public List<LeaguePositionDTO> getLeaguePositionDTO(@PathVariable String summonerName) {
         return summonerService.getLeaguePositionDTO(summonerName);
     }
 

--- a/src/main/java/org/cnu/realcoding/riotpractice/domain/LeaguePositionDTO.java
+++ b/src/main/java/org/cnu/realcoding/riotpractice/domain/LeaguePositionDTO.java
@@ -2,10 +2,8 @@ package org.cnu.realcoding.riotpractice.domain;
 
 import lombok.Data;
 
-import java.util.LinkedHashMap;
-
 @Data
-public class LeaguePositionDTO extends LinkedHashMap {
+public class LeaguePositionDTO {
     private String tier;
     private String summonerName;
     private boolean hotStreak;

--- a/src/main/java/org/cnu/realcoding/riotpractice/repository/SummonerRepository.java
+++ b/src/main/java/org/cnu/realcoding/riotpractice/repository/SummonerRepository.java
@@ -6,15 +6,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 @Repository
 public class SummonerRepository {
     @Autowired
     private MongoTemplate mongoTemplate;
 
-    public LinkedHashMap insertLeaguePositionDTO(LinkedHashMap leaguePositionDTO) {
-        return mongoTemplate.insert((new ObjectMapper()).convertValue(leaguePositionDTO, LeaguePositionDTO.class));
+    public Collection<LeaguePositionDTO> insertLeaguePositionDTOs(List<LeaguePositionDTO> leaguePositionDTOs) {
+        return mongoTemplate.insertAll(leaguePositionDTOs);
     }
 
 //    public LeaguePositionDTO findLeaguePositionBySummonerName(String summonerName) {

--- a/src/main/java/org/cnu/realcoding/riotpractice/service/SummonerService.java
+++ b/src/main/java/org/cnu/realcoding/riotpractice/service/SummonerService.java
@@ -3,12 +3,14 @@ package org.cnu.realcoding.riotpractice.service;
 import lombok.extern.slf4j.Slf4j;
 import org.cnu.realcoding.riotpractice.api.LeaguePositionDTOApiClient;
 import org.cnu.realcoding.riotpractice.api.SummonerDTOApiClient;
+import org.cnu.realcoding.riotpractice.domain.LeaguePositionDTO;
 import org.cnu.realcoding.riotpractice.domain.SummonerDTO;
 import org.cnu.realcoding.riotpractice.repository.SummonerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 
 @Service
 @Slf4j
@@ -25,11 +27,11 @@ public class SummonerService {
         return summonerDTO.getId();
     }
 
-    public LinkedHashMap getLeaguePositionDTO(String summonerName) {
+    public List<LeaguePositionDTO> getLeaguePositionDTO(String summonerName) {
         String encryptedSummonerId = getEncryptedSummonerId(summonerName);
-        LinkedHashMap leaguePositionDTO = leaguePositionDTOApiClient.getLeaguePositionDTO(encryptedSummonerId);
-        summonerRepository.insertLeaguePositionDTO(leaguePositionDTO);
-        log.info("LeaguePosition has inserted successfully. LeaguePosition : {}", leaguePositionDTO);
-        return leaguePositionDTO;
+        List<LeaguePositionDTO> leaguePositionDTOs = leaguePositionDTOApiClient.getLeaguePositionDTO(encryptedSummonerId);
+        summonerRepository.insertLeaguePositionDTOs(leaguePositionDTOs);
+        log.info("LeaguePosition has inserted successfully. LeaguePosition : {}", leaguePositionDTOs);
+        return leaguePositionDTOs;
     }
 }


### PR DESCRIPTION
restTemplate 을 사용해서 GET 메소드를 호출할 때,

Response 형식이 `{}` 이 아니고 `[]` 배열형태이면,

`ParameterizedTypeReference` 을 활용할 수 있습니다.

https://stackoverflow.com/questions/51896979/correct-usage-of-parameterizedtypereference
을 참고해보세요